### PR TITLE
Allow AArch64 builds

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-  "skip-arches": ["aarch64"],
   "skip-appstream-check": true
 }


### PR DESCRIPTION
These are allowed for the Godot editor already.