### PR TITLE
Update to FreeDesktop 22.08 runtime

### DIFF
--- a/org.godotengine.godot.BaseApp.yaml
+++ b/org.godotengine.godot.BaseApp.yaml
@@ -1,7 +1,7 @@
 app-id: org.godotengine.godot.BaseApp
 branch: '3.5'
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: godot-runner
 


### PR DESCRIPTION
21.08 runtime will be end-of-life in a few months from now.

See https://github.com/flathub/org.godotengine.Godot/pull/110.