### PR TITLE
Support Godot 4.4

### DIFF
--- a/org.godotengine.godot.BaseApp.yaml
+++ b/org.godotengine.godot.BaseApp.yaml
@@ -1,5 +1,5 @@
 app-id: org.godotengine.godot.BaseApp
-branch: '4.3-24.08'
+branch: '4.4'
 runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
@@ -56,8 +56,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 751e55bfad8e04b846f9cf7b6eb80e058986a2cb1b103fc0fe6a4d8526a20e56
-        url: https://downloads.tuxfamily.org/godotengine/4.3/godot-4.3-stable.tar.xz
+        sha256: 74053aa6a19b8751fec89a527c722e32de4d94442ec2525970c108aea89dd3e8
+        url: https://github.com/godotengine/godot-builds/releases/download/4.4-stable/godot-4.4-stable.tar.xz
 
     build-commands:
       - python3 /app/bin/scons $SCONS_FLAGS $SCONS_FLAGS_EXTRA tools=no target=template_release -j "$FLATPAK_BUILDER_N_JOBS"


### PR DESCRIPTION
I have also changed the source URL from tuxfamily to the `godot-builds` repository, as tuxfamily is less reliable, as seen in https://github.com/abarichello/godot-ci/pull/168.