### PR TITLE
Correct 4.4 branch name

### DIFF
--- a/org.godotengine.godot.BaseApp.yaml
+++ b/org.godotengine.godot.BaseApp.yaml
@@ -1,5 +1,5 @@
 app-id: org.godotengine.godot.BaseApp
-branch: '4.4.1'
+branch: '4.4'
 runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk


### PR DESCRIPTION
As of #50, my apps targeting the 4.4 BaseApp were still pulling in version 4.4 instead of 4.4.1. I believe this is due to the mismatch in the branch name defined in the BaseApp manifest.

For example, in #30, the branch name defined in the manifest remained `3.5` instead of being updated to `3.5.3`. I think the 4.4.1 update was never actually built and deployed for the BaseApp.