### PR TITLE
Fix `--main-pack` not being usable anymore since 4.6

### DIFF
--- a/org.godotengine.godot.BaseApp.yaml
+++ b/org.godotengine.godot.BaseApp.yaml
@@ -24,6 +24,7 @@ build-options:
       CCFLAGS=-I/app/include
       prefix=/app
       unix_global_settings_path=/app
+      disable_path_overrides=no
       progress=no
       builtin_freetype=no
       builtin_libogg=no


### PR DESCRIPTION
The `disable_path_overrides=no` SCons option must be used to allow `--main-pack` to be used again, as Flatpaks made with this BaseApp often require this argument.

This is only needed in 4.6 and later.

- This closes #64.
